### PR TITLE
Rebuild personal site as a minimal, information-dense single page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+- `index.html` + `styles.css` are the real personal site (minimal, static, no build step, no external requests). `game-portfolio.html` is a separate standalone entry point for the old canvas adventure-game portfolio; it and `game.js` use `game-styles.css`, not `styles.css`. Don't let edits to one stylesheet bleed into the other.
+- No JS framework, bundler, or dependency is intended for the site pages — GitHub Pages serves the repo root directly from `master`.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/game-portfolio.html
+++ b/game-portfolio.html
@@ -6,7 +6,7 @@
     <title>Laksh's Adventure Portfolio</title>
     <meta name="description" content="Welcome to Laksh's interactive portfolio - an adventure game experience!">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎮</text></svg>">
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="game-styles.css">
 </head>
 <body>
     <div class="game-container">

--- a/game-styles.css
+++ b/game-styles.css
@@ -1,0 +1,409 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Courier New', monospace;
+    background: linear-gradient(45deg, #0a0a0a, #1a1a2e, #16213e);
+    color: #00ff00;
+    overflow: hidden;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.game-container {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    max-width: 1200px;
+    max-height: 800px;
+    border: 3px solid #00ff00;
+    border-radius: 10px;
+    box-shadow: 0 0 30px rgba(0, 255, 0, 0.3), inset 0 0 20px rgba(0, 255, 0, 0.1);
+    background: #000;
+    overflow: hidden;
+}
+
+canvas {
+    width: 100%;
+    height: 100%;
+    image-rendering: pixelated;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: crisp-edges;
+    border-radius: 7px;
+}
+
+.loading-screen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(45deg, #000428, #004e92, #8e2de2);
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+    transition: opacity 0.8s ease-out;
+}
+
+.loading-text {
+    font-size: 2.5rem;
+    margin-bottom: 2rem;
+    text-align: center;
+    color: #00ff00;
+    text-shadow: 0 0 20px rgba(0, 255, 0, 0.8);
+    animation: pulse 2s infinite, glow 3s ease-in-out infinite alternate;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.8; transform: scale(1.05); }
+}
+
+@keyframes glow {
+    from { text-shadow: 0 0 20px rgba(0, 255, 0, 0.8), 0 0 30px rgba(0, 255, 0, 0.4); }
+    to { text-shadow: 0 0 20px rgba(0, 255, 0, 0.8), 0 0 40px rgba(0, 255, 0, 0.8), 0 0 50px rgba(0, 255, 0, 0.6); }
+}
+
+.loading-bar {
+    width: 350px;
+    height: 25px;
+    border: 3px solid #00ff00;
+    border-radius: 15px;
+    overflow: hidden;
+    background: #000;
+    position: relative;
+}
+
+.loading-progress {
+    height: 100%;
+    background: linear-gradient(90deg, #00ff00, #00dd00, #ffff00, #00ff00);
+    background-size: 200% 100%;
+    width: 0%;
+    transition: width 0.3s ease;
+    box-shadow: 0 0 15px rgba(0, 255, 0, 0.8);
+    animation: shimmer 2s linear infinite;
+}
+
+@keyframes shimmer {
+    0% { background-position: -200% 0; }
+    100% { background-position: 200% 0; }
+}
+
+.controls-info {
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(0, 0, 0, 0.9);
+    padding: 15px 20px;
+    border: 2px solid #00ff00;
+    border-radius: 15px;
+    font-size: 14px;
+    text-align: center;
+    color: #00ff00;
+    z-index: 500;
+    box-shadow: 0 0 20px rgba(0, 255, 0, 0.3);
+    backdrop-filter: blur(5px);
+}
+
+.ui-overlay {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    background: rgba(0, 0, 0, 0.98);
+    padding: 20px;
+    border: 3px solid #00ff00;
+    border-radius: 15px;
+    min-width: 220px;
+    z-index: 500;
+    box-shadow: 0 0 25px rgba(0, 255, 0, 0.4), inset 0 0 15px rgba(0, 255, 0, 0.1);
+    backdrop-filter: blur(12px);
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.ui-overlay div {
+    margin: 8px 0;
+    color: #00ff00;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9), 0 0 6px rgba(0, 255, 0, 0.3);
+}
+
+.health-bar {
+    width: 180px;
+    height: 12px;
+    background: #333;
+    border: 2px solid #00ff00;
+    margin: 8px 0;
+    border-radius: 8px;
+    overflow: hidden;
+    position: relative;
+}
+
+.health-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #ff0000, #ffaa00, #ffff00, #00ff00);
+    width: 100%;
+    transition: width 0.5s ease;
+    box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.3);
+}
+
+.dialog-box {
+    position: absolute;
+    bottom: 100px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 85%;
+    max-width: 700px;
+    background: rgba(0, 0, 0, 0.98); /* More opaque for better text visibility */
+    border: 4px solid #00ff00; /* Thicker border */
+    border-radius: 20px;
+    padding: 25px;
+    display: none;
+    z-index: 1000;
+    animation: slideUp 0.4s ease-out;
+    box-shadow: 0 0 40px rgba(0, 255, 0, 0.6), inset 0 0 20px rgba(0, 255, 0, 0.1);
+    backdrop-filter: blur(15px);
+}
+
+@keyframes slideUp {
+    from { 
+        transform: translateX(-50%) translateY(100px); 
+        opacity: 0; 
+        scale: 0.9;
+    }
+    to { 
+        transform: translateX(-50%) translateY(0); 
+        opacity: 1; 
+        scale: 1;
+    }
+}
+
+.dialog-text {
+    font-size: 18px;
+    line-height: 1.7;
+    color: #ffffff;
+    margin-bottom: 15px;
+    text-shadow: 0 2px 4px rgba(0, 0, 0, 1), 0 0 8px rgba(0, 255, 0, 0.3);
+    font-weight: 600;
+    letter-spacing: 0.5px;
+}
+
+.dialog-continue {
+    text-align: right;
+    font-size: 12px;
+    color: #888;
+    animation: blink 1.5s infinite;
+}
+
+@keyframes blink {
+    0%, 50% { opacity: 1; }
+    51%, 100% { opacity: 0.3; }
+}
+
+.achievement-popup {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background: linear-gradient(135deg, #ffd700, #ffb347);
+    color: #000;
+    padding: 20px 30px;
+    border-radius: 15px;
+    border: 3px solid #fff;
+    box-shadow: 0 0 30px rgba(255, 215, 0, 0.8);
+    font-weight: bold;
+    font-size: 18px;
+    z-index: 2000;
+    animation: achievementBounce 0.6s ease-out;
+    display: none;
+}
+
+@keyframes achievementBounce {
+    0% { 
+        transform: translate(-50%, -50%) scale(0.5); 
+        opacity: 0; 
+    }
+    50% { 
+        transform: translate(-50%, -50%) scale(1.1); 
+        opacity: 1; 
+    }
+    100% { 
+        transform: translate(-50%, -50%) scale(1); 
+        opacity: 1; 
+    }
+}
+
+.mini-map {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    width: 150px;
+    height: 120px;
+    background: rgba(0, 0, 0, 0.8);
+    border: 2px solid #00ff00;
+    border-radius: 10px;
+    z-index: 500;
+}
+
+/* Touch Controls for Mobile */
+.touch-controls {
+    display: none;
+    position: absolute;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 1000;
+}
+
+.touch-btn {
+    background: rgba(0, 255, 0, 0.8);
+    border: 2px solid #00ff00;
+    color: #000;
+    padding: 15px;
+    margin: 5px;
+    border-radius: 50%;
+    font-weight: bold;
+    font-size: 18px;
+    width: 60px;
+    height: 60px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    touch-action: manipulation;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.touch-btn:active {
+    background: rgba(0, 255, 0, 1);
+    transform: scale(0.95);
+}
+
+.touch-grid {
+    display: grid;
+    grid-template-columns: 60px 60px 60px;
+    grid-template-rows: 60px 60px;
+    gap: 10px;
+    align-items: center;
+    justify-items: center;
+}
+
+.interact-btn {
+    background: rgba(255, 255, 0, 0.8);
+    border-color: #ffff00;
+    grid-column: 2;
+    grid-row: 2;
+}
+
+/* Performance Optimizations */
+.game-container * {
+    -webkit-tap-highlight-color: transparent;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+/* Accessibility */
+@media (prefers-reduced-motion: reduce) {
+    * {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+    }
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+    .game-container {
+        border-radius: 0;
+        border: none;
+        max-width: 100vw;
+        max-height: 100vh;
+    }
+    
+    .loading-text {
+        font-size: 1.8rem;
+        padding: 0 20px;
+    }
+    
+    .loading-bar {
+        width: 280px;
+        height: 20px;
+    }
+    
+    .controls-info {
+        font-size: 12px;
+        padding: 12px 16px;
+        bottom: 120px; /* Moved up to make room for touch controls */
+        width: 90%;
+    }
+    
+    .ui-overlay {
+        top: 10px;
+        left: 10px;
+        padding: 15px;
+        min-width: 180px;
+        font-size: 12px;
+    }
+    
+    .dialog-box {
+        width: 95%;
+        padding: 20px;
+        bottom: 140px; /* Moved up to avoid touch controls */
+    }
+    
+    .dialog-text {
+        font-size: 16px;
+    }
+    
+    .mini-map {
+        width: 120px;
+        height: 90px;
+        top: 10px;
+        right: 10px;
+    }
+    
+    /* Show touch controls on mobile */
+    .touch-controls {
+        display: block !important;
+    }
+    
+    /* Improve touch targets */
+    .touch-btn {
+        width: 50px;
+        height: 50px;
+        font-size: 16px;
+    }
+    
+    .touch-grid {
+        grid-template-columns: 50px 50px 50px;
+        grid-template-rows: 50px 50px;
+        gap: 8px;
+    }
+}
+
+@media (max-width: 480px) {
+    .loading-text {
+        font-size: 1.4rem;
+    }
+    
+    .ui-overlay {
+        font-size: 11px;
+        min-width: 160px;
+    }
+    
+    .health-bar {
+        width: 140px;
+        height: 10px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -3,77 +3,65 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Laksh Sadhwani - Senior Backend Engineer | Adventure Portfolio</title>
-    <meta name="description" content="Welcome to Laksh's interactive portfolio - explore my journey as a Senior Backend Engineer at Razorpay through an adventure game!">
-    <meta name="keywords" content="Laksh Sadhwani, Backend Engineer, Razorpay, Golang, Python, Software Developer, NIT Karnataka">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🚀</text></svg>">
+    <title>Laksh Sadhwani</title>
+    <meta name="description" content="Laksh Sadhwani - backend engineer, occasional tool-builder.">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐙</text></svg>">
     <link rel="stylesheet" href="styles.css">
-    
-    <!-- Open Graph / Social Media -->
-    <meta property="og:type" content="website">
-    <meta property="og:title" content="Laksh Sadhwani - Senior Backend Engineer">
-    <meta property="og:description" content="Explore my journey as a Senior Backend Engineer through an interactive adventure game!">
-    <meta property="og:url" content="https://laaaaksh.github.io">
-    <meta name="twitter:card" content="summary_large_image">
 </head>
 <body>
-    <div class="game-container">
-        <div class="loading-screen" id="loadingScreen">
-            <div class="loading-text">
-                🚀 LAKSH'S ADVENTURE PORTFOLIO 🚀<br>
-                <span style="font-size: 1.2rem; color: #ffff00;">Senior Backend Engineer @ Razorpay</span><br>
-                <span style="font-size: 0.9rem;">Loading the coolest backend adventure...</span>
-            </div>
-            <div class="loading-bar">
-                <div class="loading-progress" id="loadingProgress"></div>
-            </div>
-        </div>
+    <main>
+        <h1>Laksh Sadhwani</h1>
 
-        <canvas id="gameCanvas"></canvas>
+        <p>
+            I build backend systems, mostly in Go, sometimes in Python.
+            I studied Material Science at NIT Karnataka<!-- TODO(captain): confirm degree/major is correct - carried over from game.js dialogue, not independently verified -->,
+            which is an unusual way to end up writing Go for a living, and yet.
+            <!--
+              TODO(captain): current role/employer is unclear and I did not want to guess.
+              The old site said "Senior Backend Engineer at Razorpay, 4+ years experience" -
+              likely stale. Public GitHub profile currently lists company as "Snabbit".
+              Neither has been confirmed as current. Please replace this paragraph with
+              an accurate one-liner about where you work now and how long you've been at it.
+            -->
+        </p>
 
-        <div class="ui-overlay" id="uiOverlay">
-            <div><strong>🎯 Current Zone:</strong> <span id="currentArea">Hub World</span></div>
-            <div><strong>🔥 Experience Level:</strong></div>
-            <div class="health-bar">
-                <div class="health-fill" id="healthFill"></div>
-            </div>
-            <div><strong>🏆 Discoveries:</strong> <span id="discoveries">0/20</span></div>
-            <div style="font-size: 11px; margin-top: 10px; color: #888;">
-                <div>💼 Razorpay Senior SDE</div>
-                <div>🏫 NIT Karnataka</div>
-                <div>🌟 4+ Years Experience</div>
-            </div>
-        </div>
+        <h2>Projects</h2>
+        <p>Some things I've built that are still around. Mostly Go, mostly backend, occasionally not.</p>
+        <ul>
+            <li>
+                <strong><a href="https://github.com/Laaaaksh/vessel">vessel</a></strong>
+                &mdash; a keyboard-driven TUI for Apple's native Mac containers.
+            </li>
+            <li>
+                <strong><a href="https://github.com/Laaaaksh/internal-transfers-service">internal-transfers-service</a></strong>
+                &mdash; a production-grade microservice for internal fund transfers: ACID guarantees, pessimistic locking, real test coverage.
+            </li>
+            <li>
+                <strong><a href="https://github.com/Laaaaksh/sticker-campaign-service">sticker-campaign-service</a></strong>
+                &mdash; Go + Postgres backend for a sticker-based loyalty campaign: ingestion, calculation, balance tracking, analytics.
+            </li>
+            <li>
+                <strong><a href="https://github.com/Laaaaksh/call-notes-AI">call-notes-AI</a></strong>
+                &mdash; real-time call note-taking for medical support calls, via a rule engine &rarr; NER &rarr; LLM pipeline that files itself into Salesforce.
+            </li>
+        </ul>
 
-        <div class="controls-info" id="controlsInfo">
-            🎮 <strong>WASD</strong> to explore • <strong>SPACE</strong> to interact • <strong>E</strong> for details • <strong>M</strong> for map
-        </div>
+        <h2>Writing</h2>
+        <p>
+            Nothing published yet.
+            <!-- TODO(captain): confirm there's genuinely nothing to link here (a blog, a Substack, a paper) before this ships -->
+        </p>
 
-        <div class="dialog-box" id="dialogBox">
-            <div class="dialog-text" id="dialogText"></div>
-            <div class="dialog-continue">Press ENTER to continue...</div>
-        </div>
-
-        <div class="achievement-popup" id="achievementPopup">
-            <div id="achievementText">🏆 Discovery Unlocked!</div>
-        </div>
-
-        <div class="mini-map" id="miniMap">
-            <canvas id="miniMapCanvas" width="150" height="120"></canvas>
-        </div>
-
-        <!-- Touch Controls for Mobile -->
-        <div class="touch-controls" id="touchControls">
-            <div class="touch-grid">
-                <button class="touch-btn" data-key="w">↑</button>
-                <button class="touch-btn" data-key="a">←</button>
-                <button class="touch-btn interact-btn" data-key=" ">⚡</button>
-                <button class="touch-btn" data-key="d">→</button>
-                <button class="touch-btn" data-key="s">↓</button>
-            </div>
-        </div>
-    </div>
-
-    <script src="game.js"></script>
+        <h2>Misc</h2>
+        <ul>
+            <li><a href="https://github.com/Laaaaksh">GitHub</a></li>
+            <li>
+                <a href="https://linkedin.com/in/sadhwanilaksh">LinkedIn</a>
+                <!-- TODO(captain): pulled from the repo README, not re-verified live - confirm it's still correct -->
+            </li>
+            <li><a href="mailto:laksh.sadhwani07@gmail.com">Email</a></li>
+            <li><a href="game-portfolio.html">there is a silly game version of this page</a></li>
+        </ul>
+    </main>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,409 +1,75 @@
+:root {
+    --bg: #fdfdfc;
+    --fg: #161616;
+    --muted: #666;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #161616;
+        --fg: #eeeeec;
+        --muted: #999;
+    }
+}
+
 * {
-    margin: 0;
-    padding: 0;
     box-sizing: border-box;
 }
 
 body {
-    font-family: 'Courier New', monospace;
-    background: linear-gradient(45deg, #0a0a0a, #1a1a2e, #16213e);
-    color: #00ff00;
-    overflow: hidden;
-    height: 100vh;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    margin: 0;
+    background: var(--bg);
+    color: var(--fg);
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-size: 1.05rem;
+    line-height: 1.65;
 }
 
-.game-container {
-    position: relative;
-    width: 100vw;
-    height: 100vh;
-    max-width: 1200px;
-    max-height: 800px;
-    border: 3px solid #00ff00;
-    border-radius: 10px;
-    box-shadow: 0 0 30px rgba(0, 255, 0, 0.3), inset 0 0 20px rgba(0, 255, 0, 0.1);
-    background: #000;
-    overflow: hidden;
-}
-
-canvas {
-    width: 100%;
-    height: 100%;
-    image-rendering: pixelated;
-    image-rendering: -moz-crisp-edges;
-    image-rendering: crisp-edges;
-    border-radius: 7px;
-}
-
-.loading-screen {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(45deg, #000428, #004e92, #8e2de2);
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
-    transition: opacity 0.8s ease-out;
-}
-
-.loading-text {
-    font-size: 2.5rem;
-    margin-bottom: 2rem;
-    text-align: center;
-    color: #00ff00;
-    text-shadow: 0 0 20px rgba(0, 255, 0, 0.8);
-    animation: pulse 2s infinite, glow 3s ease-in-out infinite alternate;
-}
-
-@keyframes pulse {
-    0%, 100% { opacity: 1; transform: scale(1); }
-    50% { opacity: 0.8; transform: scale(1.05); }
-}
-
-@keyframes glow {
-    from { text-shadow: 0 0 20px rgba(0, 255, 0, 0.8), 0 0 30px rgba(0, 255, 0, 0.4); }
-    to { text-shadow: 0 0 20px rgba(0, 255, 0, 0.8), 0 0 40px rgba(0, 255, 0, 0.8), 0 0 50px rgba(0, 255, 0, 0.6); }
-}
-
-.loading-bar {
-    width: 350px;
-    height: 25px;
-    border: 3px solid #00ff00;
-    border-radius: 15px;
-    overflow: hidden;
-    background: #000;
-    position: relative;
-}
-
-.loading-progress {
-    height: 100%;
-    background: linear-gradient(90deg, #00ff00, #00dd00, #ffff00, #00ff00);
-    background-size: 200% 100%;
-    width: 0%;
-    transition: width 0.3s ease;
-    box-shadow: 0 0 15px rgba(0, 255, 0, 0.8);
-    animation: shimmer 2s linear infinite;
-}
-
-@keyframes shimmer {
-    0% { background-position: -200% 0; }
-    100% { background-position: 200% 0; }
-}
-
-.controls-info {
-    position: absolute;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: rgba(0, 0, 0, 0.9);
-    padding: 15px 20px;
-    border: 2px solid #00ff00;
-    border-radius: 15px;
-    font-size: 14px;
-    text-align: center;
-    color: #00ff00;
-    z-index: 500;
-    box-shadow: 0 0 20px rgba(0, 255, 0, 0.3);
-    backdrop-filter: blur(5px);
-}
-
-.ui-overlay {
-    position: absolute;
-    top: 20px;
-    left: 20px;
-    background: rgba(0, 0, 0, 0.98);
-    padding: 20px;
-    border: 3px solid #00ff00;
-    border-radius: 15px;
-    min-width: 220px;
-    z-index: 500;
-    box-shadow: 0 0 25px rgba(0, 255, 0, 0.4), inset 0 0 15px rgba(0, 255, 0, 0.1);
-    backdrop-filter: blur(12px);
-    font-size: 14px;
-    font-weight: 600;
-}
-
-.ui-overlay div {
-    margin: 8px 0;
-    color: #00ff00;
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9), 0 0 6px rgba(0, 255, 0, 0.3);
-}
-
-.health-bar {
-    width: 180px;
-    height: 12px;
-    background: #333;
-    border: 2px solid #00ff00;
-    margin: 8px 0;
-    border-radius: 8px;
-    overflow: hidden;
-    position: relative;
-}
-
-.health-fill {
-    height: 100%;
-    background: linear-gradient(90deg, #ff0000, #ffaa00, #ffff00, #00ff00);
-    width: 100%;
-    transition: width 0.5s ease;
-    box-shadow: inset 0 0 10px rgba(255, 255, 255, 0.3);
-}
-
-.dialog-box {
-    position: absolute;
-    bottom: 100px;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 85%;
+main {
     max-width: 700px;
-    background: rgba(0, 0, 0, 0.98); /* More opaque for better text visibility */
-    border: 4px solid #00ff00; /* Thicker border */
-    border-radius: 20px;
-    padding: 25px;
-    display: none;
-    z-index: 1000;
-    animation: slideUp 0.4s ease-out;
-    box-shadow: 0 0 40px rgba(0, 255, 0, 0.6), inset 0 0 20px rgba(0, 255, 0, 0.1);
-    backdrop-filter: blur(15px);
+    margin: 0 auto;
+    padding: 4rem 1.5rem 6rem;
 }
 
-@keyframes slideUp {
-    from { 
-        transform: translateX(-50%) translateY(100px); 
-        opacity: 0; 
-        scale: 0.9;
-    }
-    to { 
-        transform: translateX(-50%) translateY(0); 
-        opacity: 1; 
-        scale: 1;
-    }
+h1 {
+    font-size: 1.9rem;
+    font-weight: 700;
+    margin: 0 0 1.5rem;
 }
 
-.dialog-text {
-    font-size: 18px;
-    line-height: 1.7;
-    color: #ffffff;
-    margin-bottom: 15px;
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 1), 0 0 8px rgba(0, 255, 0, 0.3);
-    font-weight: 600;
-    letter-spacing: 0.5px;
+h2 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    margin: 2.75rem 0 0.75rem;
 }
 
-.dialog-continue {
-    text-align: right;
-    font-size: 12px;
-    color: #888;
-    animation: blink 1.5s infinite;
+p {
+    margin: 0 0 1rem;
 }
 
-@keyframes blink {
-    0%, 50% { opacity: 1; }
-    51%, 100% { opacity: 0.3; }
+p + p {
+    margin-top: 1rem;
 }
 
-.achievement-popup {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background: linear-gradient(135deg, #ffd700, #ffb347);
-    color: #000;
-    padding: 20px 30px;
-    border-radius: 15px;
-    border: 3px solid #fff;
-    box-shadow: 0 0 30px rgba(255, 215, 0, 0.8);
-    font-weight: bold;
-    font-size: 18px;
-    z-index: 2000;
-    animation: achievementBounce 0.6s ease-out;
-    display: none;
+ul {
+    margin: 0 0 1rem;
+    padding-left: 1.25rem;
 }
 
-@keyframes achievementBounce {
-    0% { 
-        transform: translate(-50%, -50%) scale(0.5); 
-        opacity: 0; 
-    }
-    50% { 
-        transform: translate(-50%, -50%) scale(1.1); 
-        opacity: 1; 
-    }
-    100% { 
-        transform: translate(-50%, -50%) scale(1); 
-        opacity: 1; 
-    }
+li {
+    margin-bottom: 0.6rem;
 }
 
-.mini-map {
-    position: absolute;
-    top: 20px;
-    right: 20px;
-    width: 150px;
-    height: 120px;
-    background: rgba(0, 0, 0, 0.8);
-    border: 2px solid #00ff00;
-    border-radius: 10px;
-    z-index: 500;
+a {
+    color: inherit;
+    text-decoration-color: var(--muted);
+    text-underline-offset: 2px;
 }
 
-/* Touch Controls for Mobile */
-.touch-controls {
-    display: none;
-    position: absolute;
-    bottom: 20px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 1000;
+a:hover {
+    text-decoration-color: var(--fg);
 }
 
-.touch-btn {
-    background: rgba(0, 255, 0, 0.8);
-    border: 2px solid #00ff00;
-    color: #000;
-    padding: 15px;
-    margin: 5px;
-    border-radius: 50%;
-    font-weight: bold;
-    font-size: 18px;
-    width: 60px;
-    height: 60px;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    user-select: none;
-    touch-action: manipulation;
-    cursor: pointer;
-    transition: all 0.2s ease;
-}
-
-.touch-btn:active {
-    background: rgba(0, 255, 0, 1);
-    transform: scale(0.95);
-}
-
-.touch-grid {
-    display: grid;
-    grid-template-columns: 60px 60px 60px;
-    grid-template-rows: 60px 60px;
-    gap: 10px;
-    align-items: center;
-    justify-items: center;
-}
-
-.interact-btn {
-    background: rgba(255, 255, 0, 0.8);
-    border-color: #ffff00;
-    grid-column: 2;
-    grid-row: 2;
-}
-
-/* Performance Optimizations */
-.game-container * {
-    -webkit-tap-highlight-color: transparent;
-    -webkit-touch-callout: none;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-}
-
-/* Accessibility */
-@media (prefers-reduced-motion: reduce) {
-    * {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-    }
-}
-
-/* Mobile Responsive */
-@media (max-width: 768px) {
-    .game-container {
-        border-radius: 0;
-        border: none;
-        max-width: 100vw;
-        max-height: 100vh;
-    }
-    
-    .loading-text {
-        font-size: 1.8rem;
-        padding: 0 20px;
-    }
-    
-    .loading-bar {
-        width: 280px;
-        height: 20px;
-    }
-    
-    .controls-info {
-        font-size: 12px;
-        padding: 12px 16px;
-        bottom: 120px; /* Moved up to make room for touch controls */
-        width: 90%;
-    }
-    
-    .ui-overlay {
-        top: 10px;
-        left: 10px;
-        padding: 15px;
-        min-width: 180px;
-        font-size: 12px;
-    }
-    
-    .dialog-box {
-        width: 95%;
-        padding: 20px;
-        bottom: 140px; /* Moved up to avoid touch controls */
-    }
-    
-    .dialog-text {
-        font-size: 16px;
-    }
-    
-    .mini-map {
-        width: 120px;
-        height: 90px;
-        top: 10px;
-        right: 10px;
-    }
-    
-    /* Show touch controls on mobile */
-    .touch-controls {
-        display: block !important;
-    }
-    
-    /* Improve touch targets */
-    .touch-btn {
-        width: 50px;
-        height: 50px;
-        font-size: 16px;
-    }
-    
-    .touch-grid {
-        grid-template-columns: 50px 50px 50px;
-        grid-template-rows: 50px 50px;
-        gap: 8px;
-    }
-}
-
-@media (max-width: 480px) {
-    .loading-text {
-        font-size: 1.4rem;
-    }
-    
-    .ui-overlay {
-        font-size: 11px;
-        min-width: 160px;
-    }
-    
-    .health-bar {
-        width: 140px;
-        height: 10px;
-    }
+strong {
+    font-weight: 700;
 }


### PR DESCRIPTION
## Summary

Rewrites `index.html` + `styles.css` as a plain, single-column, information-dense page — modelled on the aesthetic of https://benjaminfspector.com/ (system sans-serif, near-black on near-white, ~700px column, no nav/cards/icons/gradients, section headers only). No framework, no build step, no dependency — same as before, GitHub Pages serves it directly.

Section order: intro paragraph → Projects → Writing → Misc, per the brief.

- **Projects**: `vessel` (required), plus `internal-transfers-service`, `sticker-campaign-service`, `call-notes-AI` — the genuinely substantial, non-fork, non-coursework repos on github.com/Laaaaksh. Skipped throwaway/scaffold repos (empty descriptions, coursework, forks).
- **Writing**: no published writing was found anywhere I could check (repo, GitHub profile, blog link points back to this same site) — left as an honest placeholder line instead of inventing entries.
- **Misc**: GitHub, LinkedIn (from the repo README), email (from `game.js`), and a plain-text link to the game as an easter egg.
- Added `prefers-color-scheme: dark` support — inverted monochrome only, nothing else changes.

### Preserving the game

`game-portfolio.html` already existed as a standalone entry point for the canvas-game version of the portfolio, sharing `styles.css` with the old `index.html`. Since `styles.css` needed a full rewrite for the new minimal page, I copied the original file to **`game-styles.css`** and repointed `game-portfolio.html`'s one `<link>` tag at it — the only change to that file. `game.js` and `reddit-autoscroller/` are untouched. Confirmed the game still renders (loading screen, neon/gradient styling) via `chrome-devtools-axi`; there is one pre-existing console error (`miniMapCanvas` is `null` because that element only exists in the old full `index.html` markup, not in `game-portfolio.html`) — this bug predates this PR (verified via `git diff master -- game-portfolio.html`, the only change is the stylesheet href) and is out of scope here.

### Biography — nothing invented

The old site hard-coded "Senior Backend Engineer at Razorpay", "NIT Karnataka", "4+ years experience". I did not carry these forward as fact. What I found:
- Old site / `game.js`: Razorpay, NIT Karnataka (Material Science), "4+ years" in one place and "3+ years" in another (internally inconsistent).
- Public GitHub profile (`gh api user`) currently lists **company: "Snabbit"**, not Razorpay, not Scaler.

Given three different, mutually inconsistent signals about current employer, I left it as a `TODO(captain)` HTML comment rather than guess. **Every uncertain fact is marked `TODO(captain):` directly in `index.html`:**

1. Current employer / role and years of experience (intro paragraph) — old site said Razorpay, GitHub profile says Snabbit, neither confirmed current.
2. Degree/major at NIT Karnataka — carried over from `game.js` dialogue text, not independently verified.
3. Writing section — confirm there's genuinely nothing to link (blog, Substack, paper) before this ships.
4. LinkedIn URL — pulled from the repo README (`linkedin.com/in/sadhwanilaksh`), not re-verified live.

## Verification (chrome-devtools-axi)

Opened `index.html` via `file://` (no server) and checked:
- **375px** (light + dark) — single column reflows cleanly, no overflow, text wraps normally.
- **768px** (light) — same, comfortable margins.
- **1440px** (light + dark) — content stays capped at ~700px and centers, doesn't stretch full width.
- **Dark mode** (`emulate --color-scheme dark`) — inverts to near-black background / near-white text, nothing else changes (no accent colors, no shift in the game's own styling since it's a separate stylesheet now).
- **Network tab**: exactly 2 requests on page load — `index.html` and `styles.css`, both `file://`. Zero external requests.
- `index.html` (3.4KB) + `styles.css` (1KB) ≈ 4.5KB total, well under the 50KB budget.

## Test plan

- [ ] Fill in the 4 `TODO(captain)` items in `index.html` (search for `TODO(captain)`)
- [ ] Open `index.html` directly in a browser (no server) and confirm it still looks right
- [ ] Confirm `game-portfolio.html` still plays correctly end-to-end (I only verified the loading screen renders)
- [ ] Merge or request changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)