### PR TITLE
Add hello: terminal-style GitHub profile age page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 - Add durable project-specific notes here as they are discovered through real work.
 - `index.html` + `styles.css` are the real personal site (minimal, static, no build step, no external requests). `game-portfolio.html` is a separate standalone entry point for the old canvas adventure-game portfolio; it and `game.js` use `game-styles.css`, not `styles.css`. Don't let edits to one stylesheet bleed into the other.
+- `hello/index.html` is a fully self-contained page (inline CSS/JS, no shared stylesheet) at the fixed public path `https://laaaaksh.github.io/hello/` — linked from the profile README, so that path is a contract.
 - No JS framework, bundler, or dependency is intended for the site pages — GitHub Pages serves the repo root directly from `master`.
 
 ## Maintaining this file

--- a/hello/index.html
+++ b/hello/index.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>~/hello &mdash; github profile age</title>
+    <meta name="description" content="Type a GitHub username, get its age. Terminal-style.">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='14' fill='%230b0f0c'/><text x='50' y='68' font-size='52' font-family='monospace' fill='%233fe072' text-anchor='middle'>&gt;_</text></svg>">
+    <style>
+        :root {
+            --bg: #080b09;
+            --term: #0d120e;
+            --edge: #1e2a21;
+            --fg: #b8c4ba;
+            --muted: #5b6a5f;
+            --accent: #3fe072;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html {
+            background: var(--bg);
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: clamp(1rem, 6vh, 4rem) 1rem 3rem;
+            background: var(--bg);
+            color: var(--fg);
+            font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+            font-size: 15px;
+            line-height: 1.7;
+            -webkit-font-smoothing: antialiased;
+        }
+
+        .term {
+            width: 100%;
+            max-width: 620px;
+            background: var(--term);
+            border: 1px solid var(--edge);
+            border-radius: 8px;
+            box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55);
+            overflow: hidden;
+        }
+
+        .term-bar {
+            display: flex;
+            align-items: center;
+            gap: 7px;
+            padding: 10px 14px;
+            border-bottom: 1px solid var(--edge);
+            background: rgba(255, 255, 255, 0.02);
+        }
+
+        .dot {
+            width: 11px;
+            height: 11px;
+            border-radius: 50%;
+            background: var(--edge);
+        }
+
+        .term-title {
+            flex: 1;
+            text-align: center;
+            color: var(--muted);
+            font-size: 12px;
+            letter-spacing: 0.04em;
+            user-select: none;
+        }
+
+        .term-body {
+            padding: 18px 18px 22px;
+            min-height: 300px;
+        }
+
+        .line {
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
+        .muted { color: var(--muted); }
+        .accent { color: var(--accent); }
+        .err::before { content: "! "; color: var(--accent); }
+
+        .greeting {
+            color: var(--accent);
+            font-size: 1.65rem;
+            line-height: 1.35;
+            font-weight: 700;
+            margin: 0.4rem 0 0.2rem;
+            text-shadow: 0 0 18px rgba(63, 224, 114, 0.25);
+        }
+
+        .age-line {
+            margin-top: 0.9rem;
+        }
+
+        .fact {
+            display: flex;
+            gap: 0;
+        }
+
+        .fact .k {
+            color: var(--muted);
+            flex: 0 0 11ch;
+        }
+
+        .fact .v {
+            color: var(--fg);
+            word-break: break-word;
+        }
+
+        a {
+            color: var(--accent);
+            text-decoration: none;
+            border-bottom: 1px dotted var(--muted);
+        }
+
+        a:hover {
+            border-bottom-color: var(--accent);
+        }
+
+        .avatar-frame {
+            display: inline-block;
+            margin: 0.8rem 0 0.4rem;
+            border: 1px solid var(--edge);
+            border-radius: 6px;
+            overflow: hidden;
+            vertical-align: top;
+        }
+
+        .avatar-frame .bar {
+            padding: 3px 10px;
+            font-size: 11px;
+            color: var(--muted);
+            border-bottom: 1px solid var(--edge);
+            background: rgba(255, 255, 255, 0.02);
+            user-select: none;
+        }
+
+        .avatar-frame img {
+            display: block;
+            width: 96px;
+            height: 96px;
+            image-rendering: auto;
+        }
+
+        .prompt-row {
+            display: flex;
+            align-items: baseline;
+            margin-top: 1.1rem;
+        }
+
+        .prompt-row.hidden {
+            display: none;
+        }
+
+        .prompt-row label {
+            color: var(--fg);
+            white-space: pre;
+        }
+
+        .prompt-row input {
+            background: transparent;
+            border: none;
+            outline: none;
+            color: var(--accent);
+            caret-color: transparent;
+            font-family: inherit;
+            font-size: 16px; /* >=16px so iOS Safari doesn't zoom on focus */
+            padding: 0;
+            margin: 0 0 0 1ch;
+            width: 2ch;
+            min-width: 2ch;
+        }
+
+        .cursor {
+            display: inline-block;
+            width: 0.62em;
+            height: 1.15em;
+            margin-left: 1px;
+            background: var(--accent);
+            vertical-align: text-bottom;
+            animation: blink 1.06s steps(1) infinite;
+        }
+
+        @keyframes blink {
+            50% { opacity: 0; }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            .cursor { animation: none; }
+        }
+
+        .back-link {
+            margin-top: 2.2rem;
+            font-size: 13px;
+            color: var(--muted);
+        }
+
+        .back-link a {
+            color: var(--muted);
+            border-bottom-color: transparent;
+        }
+
+        .back-link a:hover {
+            color: var(--accent);
+        }
+
+    </style>
+</head>
+<body>
+    <div class="term" id="term">
+        <div class="term-bar">
+            <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+            <span class="term-title">laksh@github: ~/hello</span>
+        </div>
+        <div class="term-body" id="termBody">
+            <div id="out"></div>
+
+            <form class="prompt-row hidden" id="promptForm" autocomplete="off">
+                <label for="username" id="promptLabel">&gt; enter github username:</label><input
+                    id="username" type="text" autocapitalize="off" autocomplete="off"
+                    autocorrect="off" spellcheck="false" enterkeyhint="go"
+                    aria-label="github username"><span class="cursor" aria-hidden="true"></span>
+            </form>
+
+            <div class="back-link">&gt; <a href="https://github.com/Laaaaksh">back to profile</a></div>
+        </div>
+    </div>
+
+    <script>
+    (function () {
+        "use strict";
+
+        var out = document.getElementById("out");
+        var termBody = document.getElementById("termBody");
+        var form = document.getElementById("promptForm");
+        var input = document.getElementById("username");
+        var label = document.getElementById("promptLabel");
+
+        var reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        var skip = false;
+
+        function sleep(ms) {
+            if (skip || reducedMotion) return Promise.resolve();
+            return new Promise(function (r) { setTimeout(r, ms); });
+        }
+
+        function scrollBottom() {
+            window.scrollTo({ top: document.body.scrollHeight });
+        }
+
+        function addLine(cls) {
+            var el = document.createElement("div");
+            el.className = "line" + (cls ? " " + cls : "");
+            out.appendChild(el);
+            return el;
+        }
+
+        async function typeLine(text, cls, speed) {
+            var el = addLine(cls);
+            if (reducedMotion) { el.textContent = text; return el; }
+            for (var i = 0; i < text.length; i++) {
+                if (skip) { el.textContent = text; break; }
+                el.textContent += text[i];
+                scrollBottom();
+                await sleep(speed || 16);
+            }
+            return el;
+        }
+
+        function instantLine(text, cls) {
+            var el = addLine(cls);
+            el.textContent = text;
+            return el;
+        }
+
+        // ---- prompt handling -------------------------------------------------
+
+        function showPrompt(text) {
+            label.textContent = "> " + (text || "enter github username:");
+            form.classList.remove("hidden");
+            input.value = "";
+            resizeInput();
+            input.focus({ preventScroll: true });
+        }
+
+        function hidePrompt() {
+            form.classList.add("hidden");
+        }
+
+        function resizeInput() {
+            input.style.width = Math.max(input.value.length, 1) + 1 + "ch";
+        }
+
+        input.addEventListener("input", resizeInput);
+
+        form.addEventListener("submit", function (e) {
+            e.preventDefault();
+            var raw = input.value.trim().replace(/^@+/, "");
+            if (!raw) return;
+            hidePrompt();
+            lookup(raw);
+        });
+
+        // tap anywhere in the terminal focuses the input when idle,
+        // and fast-forwards the typewriter while it is running
+        document.getElementById("term").addEventListener("pointerdown", function () {
+            if (!form.classList.contains("hidden")) input.focus({ preventScroll: true });
+        });
+
+        document.addEventListener("keydown", function () {
+            if (skip) return;
+            if (!form.classList.contains("hidden") && document.activeElement === input) return;
+            skip = true;
+        });
+
+        // ---- github api ------------------------------------------------------
+
+        function profileAge(createdStr) {
+            var created = new Date(createdStr);
+            var now = new Date();
+            var years = now.getFullYear() - created.getFullYear();
+            var anniversary = new Date(created);
+            anniversary.setFullYear(created.getFullYear() + years);
+            if (anniversary > now) {
+                years -= 1;
+                anniversary.setFullYear(created.getFullYear() + years);
+            }
+            var days = Math.max(0, Math.floor((now - anniversary) / 86400000));
+            return { years: years, days: days };
+        }
+
+        function plural(n, word) { return n === 1 ? "1 " + word : n + " " + word + "s"; }
+
+        function fetchUser(handle) {
+            var controller = new AbortController();
+            var timer = setTimeout(function () { controller.abort(); }, 15000);
+            return fetch("https://api.github.com/users/" + encodeURIComponent(handle), {
+                signal: controller.signal,
+                headers: { "Accept": "application/vnd.github+json" }
+            }).then(function (res) {
+                clearTimeout(timer);
+                return res.json().catch(function () { return {}; })
+                    .then(function (data) { return { status: res.status, data: data }; });
+            }, function (err) {
+                clearTimeout(timer);
+                throw err;
+            });
+        }
+
+        // ---- reveal ----------------------------------------------------------
+
+        async function lookup(handle) {
+            skip = false;
+            instantLine("> " + handle, "muted");
+
+            var status = addLine("muted spinner on");
+            var frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+            var fi = 0;
+            status.textContent = "querying api.github.com for @" + handle + " ";
+            var spin = setInterval(function () {
+                status.textContent = "querying api.github.com for @" + handle + " " + frames[fi++ % frames.length];
+            }, 90);
+
+            var res;
+            try {
+                if (!navigator.onLine) throw { offline: true };
+                res = await fetchUser(handle);
+            } catch (err) {
+                clearInterval(spin);
+                status.remove();
+                if (err && err.offline) {
+                    await typeLine("no connection. check your network and try again.", "err", 12);
+                } else {
+                    await typeLine("connection lost or too slow. try again in a moment.", "err", 12);
+                }
+                showPrompt("try another handle?");
+                return;
+            }
+            clearInterval(spin);
+
+            if (res.status === 403 || res.status === 429) {
+                status.remove();
+                await typeLine("the matrix is busy (rate limit). grab a coffee, try again in a bit.", "err", 12);
+                showPrompt("try again shortly?");
+                return;
+            }
+
+            if (res.status >= 500) {
+                status.remove();
+                await typeLine("github is having a moment. try again shortly.", "err", 12);
+                showPrompt("try again shortly?");
+                return;
+            }
+
+            if (res.status === 404 || !res.data || !res.data.login) {
+                status.remove();
+                await typeLine("user not found. try another handle?", "err", 14);
+                showPrompt("try another handle?");
+                return;
+            }
+
+            status.textContent = "querying api.github.com for @" + handle + " ok";
+
+            var u = res.data;
+            var displayName = u.name || u.login;
+
+            await sleep(350);
+            await typeLine("Hi, " + displayName + "!", "greeting", 60);
+            await sleep(420);
+
+            if (u.avatar_url) {
+                var frame = document.createElement("div");
+                frame.className = "avatar-frame";
+                var bar = document.createElement("div");
+                bar.className = "bar";
+                bar.textContent = "[avatar]";
+                var img = document.createElement("img");
+                img.alt = "@" + u.login + "'s avatar";
+                img.src = u.avatar_url + (u.avatar_url.indexOf("?") >= 0 ? "&" : "?") + "s=192";
+                img.onerror = function () { frame.style.display = "none"; };
+                frame.appendChild(bar);
+                frame.appendChild(img);
+                out.appendChild(frame);
+                scrollBottom();
+                await sleep(250);
+            }
+
+            var age = profileAge(u.created_at);
+            var ageText = age.years > 0
+                ? plural(age.years, "year") + ", " + plural(age.days, "day")
+                : plural(age.days, "day");
+            var ageEl = await typeLine("profile age: ", "age-line", 24);
+            var strong = document.createElement("span");
+            strong.className = "accent";
+            strong.textContent = ageText;
+            ageEl.appendChild(strong);
+            scrollBottom();
+            await sleep(380);
+
+            var facts = [];
+            if (u.bio) facts.push(["bio", u.bio]);
+            if (typeof u.public_repos === "number") facts.push(["repos", plural(u.public_repos, "public repo")]);
+            if (typeof u.followers === "number") facts.push(["followers", String(u.followers)]);
+            if (u.location) facts.push(["location", u.location]);
+            if (u.company) facts.push(["company", u.company]);
+
+            for (var i = 0; i < facts.length; i++) {
+                var row = addLine("fact");
+                var k = document.createElement("span");
+                k.className = "k";
+                k.textContent = facts[i][0] + ":";
+                var v = document.createElement("span");
+                v.className = "v";
+                v.textContent = facts[i][1];
+                row.appendChild(k);
+                row.appendChild(v);
+                scrollBottom();
+                await sleep(reducedMotion ? 0 : 130);
+            }
+
+            if (u.blog) {
+                var blogRow = addLine("fact");
+                var bk = document.createElement("span");
+                bk.className = "k";
+                bk.textContent = "blog:";
+                var bl = document.createElement("a");
+                var href = /^https?:\/\//i.test(u.blog) ? u.blog : "https://" + u.blog;
+                bl.href = href;
+                bl.target = "_blank";
+                bl.rel = "noopener noreferrer";
+                bl.textContent = u.blog;
+                blogRow.appendChild(bk);
+                blogRow.appendChild(bl);
+                scrollBottom();
+            }
+
+            await sleep(300);
+            showPrompt("another handle?");
+        }
+
+        // ---- boot ------------------------------------------------------------
+
+        (async function boot() {
+            await typeLine("$ ./hello --init", "muted", 26);
+            await typeLine("profile-age-os v1.0 ... ok", "muted", 14);
+            await sleep(200);
+            showPrompt("enter github username:");
+        })();
+    })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Single self-contained page at the fixed contract path `hello/index.html` (`https://laaaaksh.github.io/hello/`).

- Terminal aesthetic matching the site's minimalism: dark, monospace, one accent color, blinking block cursor, boot-sequence typewriter intro
- Flow: prompt for a username -> `api.github.com/users/<name>` -> typed reveal: greeting (falls back to login), avatar in terminal chrome frame, profile age (full years + remainder days), fact sheet (bio/repos/followers/location/company/blog when present)
- Error states in-voice: 404 not found, 403/429 rate limit, network failure/timeout; prompt returns for retry
- Mobile-ready: real input (Enter submits), 16px font to prevent iOS zoom, responsive layout; tap/key skips the typing animation; respects prefers-reduced-motion
- No libraries, no build step; ~16.7KB raw / 4.6KB gzipped

Verified via chrome-devtools: happy path (real user), no-name/no-bio user, nonexistent user, stubbed 403 and fetch-rejection — all with zero console errors on the happy path; works over http:// and file://.