### PR TITLE
Drop the emoji favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>laksh sadhwani</title>
     <meta name="description" content="Laksh Sadhwani - building vessel and writ, learning cuda, reading philosophy.">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐙</text></svg>">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>


### PR DESCRIPTION
Removes the 🐙 data-URI favicon from `index.html`. It read as noise in the tab strip and wasn't carrying any meaning.

With no `rel="icon"` declared, the browser falls back to its own default page icon. If you'd rather have something there than nothing, an inline SVG with a letter, or a real `.png` under `assets/`, are both easy follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)