### PR TITLE
add ten open-source tools, refresh intro

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>laksh sadhwani</title>
-    <meta name="description" content="Laksh Sadhwani - building vessel and writ, learning cuda, reading philosophy.">
+    <meta name="description" content="Laksh Sadhwani - building vessel and writ, ten open-source tools shipped, learning cuda, reading philosophy.">
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -22,7 +22,9 @@
     is a keyboard-driven tui for apple&rsquo;s native mac containers.
     <a href="https://github.com/Laaaaksh/writ">writ</a> is for the other half of my day: agents
     work under a writ, and the tool checks whether they stayed inside it, then shows you only the
-    drift. both are open source. if either sounds interesting, come break them.
+    drift. i&rsquo;ve also built and open-sourced ten smaller tools, each one replacing a paid
+    developer service, listed further down the page. all twelve are open source. if any of them
+    sound interesting, come break them.
 </p>
 
 <p>
@@ -82,6 +84,21 @@
 <ul>
     <li><a href="https://github.com/Laaaaksh/vessel">vessel</a>, a keyboard-driven tui for apple&rsquo;s native mac containers</li>
     <li><a href="https://github.com/Laaaaksh/writ">writ</a>, which shows you where an agent drifted outside its writ</li>
+</ul>
+
+<h3>things i shipped, that replace a paid service</h3>
+
+<ul>
+    <li><a href="https://github.com/Laaaaksh/escalight">escalight</a>, self-hosted on-call escalation and paging, one binary and one sqlite file</li>
+    <li><a href="https://github.com/Laaaaksh/pageflag">pageflag</a>, click anything on a live page, leave a comment, triage it in a dashboard</li>
+    <li><a href="https://github.com/Laaaaksh/changeflare">changeflare</a>, an embeddable &lsquo;what&rsquo;s new&rsquo; widget with an unread badge and real analytics</li>
+    <li><a href="https://github.com/Laaaaksh/pilestack">pilestack</a>, stacked pull-request review, without the saas</li>
+    <li><a href="https://github.com/Laaaaksh/diffboard">diffboard</a>, visual regression testing with a review dashboard</li>
+    <li><a href="https://github.com/Laaaaksh/clipfolio">clipfolio</a>, business video hosting with retention curves and lead capture</li>
+    <li><a href="https://github.com/Laaaaksh/perfnest">perfnest</a>, scheduled lighthouse runs with performance budgets and alerting</li>
+    <li><a href="https://github.com/Laaaaksh/seatkey">seatkey</a>, license-key issuance and activation for indie software</li>
+    <li><a href="https://github.com/Laaaaksh/leakboard">leakboard</a>, self-hosted secret scanning across your github org</li>
+    <li><a href="https://github.com/Laaaaksh/shufflebase">shufflebase</a>, schema-aware synthetic test data and masking for postgres and mysql</li>
 </ul>
 
 <h3>misc</h3>


### PR DESCRIPTION
## Summary
- Rewrote the intro paragraph: it said "building two things" (vessel, writ) — now it also mentions the ten shipped, open-sourced tools further down the page, and keeps a "come break them" close. Updated the `<meta name="description">` to match.
- Added a new `<h3>things i shipped, that replace a paid service</h3>` section with all ten tools, each linking to `https://github.com/Laaaaksh/<repo>`.

## Design choice
Kept the ten separate from the existing "things i did" list rather than merging into one 12-item list: vessel and writ are ongoing/unfinished work, the ten are shipped, and two grouped sections read better than one long flat list.

## Test plan
- [x] Rewrote one-liners into the page's lowercase, unhyped voice (no product-copy phrasing from the GitHub descriptions)
- [x] No new CSS, files, JS, images, or badges — `styles.css` untouched
- [x] Served locally (`python3 -m http.server`) and inspected via chrome-devtools-axi: page structure and all 12 links verified, screenshot confirms layout/spacing/voice unchanged
- [x] Checked all ten repo slugs against the task table