### PR TITLE
Add mounterra innovations advisory line

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,12 @@
     a living, and yet.
 </p>
 
+<p>
+    i also advise <a href="https://www.mounterra.in/">mounterra innovations</a> on ai and technical
+    direction. they&rsquo;re a digital product development agency building ai-powered platforms, web
+    and mobile apps, and saas products for startups and industrial companies.
+</p>
+
 <h3>some things i believe</h3>
 
 <ul>


### PR DESCRIPTION
Adds one line noting the ongoing advisory role at mounterra innovations (https://www.mounterra.in/), matching the page's lowercase, unhyped voice.

Placement: added as a new paragraph after the nit karnataka education paragraph, at the end of the career block, rather than folding it into the "right now i'm building" section — it reads as the natural chronological endpoint (snabbit → razorpay → education → ongoing advisory) without disturbing the "and before that" reference back to snabbit.

Meta description left unchanged (deliberate call) — it's already a distinct summary and doesn't need every fact folded in.

Note: browser automation wasn't available in this environment to visually verify, so this was checked by reading the source and the paragraph chain in order.